### PR TITLE
many bug fixes:

### DIFF
--- a/AS5600.cpp
+++ b/AS5600.cpp
@@ -1,77 +1,84 @@
 #include "Arduino.h"
 #include "AS5600.h"
 
-AS5600::AS5600()
-{
-  //set up AS5600
+AS5600::AS5600() {
   Wire.begin();
-
-}
-long AS5600::getPosition()
-{
-  return _getRegisters2(_RAWANGLEAddressMSB, _RAWANGLEAddressLSB);  
 }
 
-int AS5600::getAngle()
-{
-  return _getRegisters2(_ANGLEAddressMSB, _ANGLEAddressLSB);  
+uint16_t AS5600::getPosition() {
+  return _getRegisters2(_RAWANGLEAddressMSB, _RAWANGLEAddressLSB);
 }
 
-int AS5600::getStatus()
-{
+uint16_t AS5600::getAngle() {
+  return _getRegisters2(_ANGLEAddressMSB, _ANGLEAddressLSB);
+}
+
+uint16_t AS5600::getRawAngle() {
+  return _getRegisters2(_RAWANGLEAddressMSB, _RAWANGLEAddressLSB);
+}
+
+float AS5600::getScaledAngle() {
+  int ang_hi = _getRegister(_RAWANGLEAddressMSB);
+  int ang_lo = _getRegister(_RAWANGLEAddressLSB);
+  return ang_hi * 22.5 + ang_lo * 0.087890625;
+}
+
+uint8_t AS5600::getStatus() {
   return _getRegister(_STATUSAddress) & 0b00111000;
 }
 
-int AS5600::getGain()
-{
+bool AS5600::isMagnetTooStrong() {
+  uint8_t _b=0;
+  _b = getStatus();
+  if (_b & (1<<5)) { return true; }
+  return false;
+}
+
+bool AS5600::isMagnetTooWeak() {
+  uint8_t _b=0;
+  _b = getStatus();
+  if (_b & (1<<4)) { return true; }
+  return false;
+}
+
+bool AS5600::isMagnetDetected() {
+  uint8_t _b=0;
+  _b = getStatus();
+  if (_b & (1<<3)) { return true; }
+  return false;
+}
+
+uint8_t AS5600::getGain() {
   return _getRegister(_AGCAddress);
 }
 
-int AS5600::getMagnitude()
-{
+uint8_t AS5600::getMagnet() {
+  return _getRegister(_AGCAddress);
+}
+
+uint16_t AS5600::getMagnitude() {
   return _getRegisters2(_MAGNITUDEAddressMSB, _MAGNITUDEAddressLSB);
 }
 
-int AS5600::_getRegister(byte register1)
-{
+uint8_t AS5600::_getRegister(byte register1) {
+  uint8_t _b=0;
+
   Wire.beginTransmission(_AS5600Address);
   Wire.write(register1);
   Wire.endTransmission();
 
-  Wire.requestFrom(_AS5600Address, 1);
+  Wire.requestFrom(_AS5600Address, 1, 0);
 
-  if(Wire.available() <=1) {
-    _msb = Wire.read();
-  }
+  while (Wire.available() == 0) { }
+  _b = Wire.read();
 
-  return _msb;
+  return _b;
 }
 
-long AS5600::_getRegisters2(byte registerMSB, byte registerLSB)
-{
-  _lsb = 0;
-  _msb = 0;
-  
-  Wire.beginTransmission(_AS5600Address);
-  Wire.write(registerMSB);
-  Wire.endTransmission();
-  delay(10);
+uint16_t AS5600::_getRegisters2(byte registerMSB, byte registerLSB) {
+  uint16_t _hi=0, _lo=0;
 
-  Wire.requestFrom(_AS5600Address, 1);
-
-  if(Wire.available() <=1) {
-    _msb = Wire.read();
-  }
-
-  Wire.requestFrom(_AS5600Address, 1);
-
-  Wire.beginTransmission(_AS5600Address);
-  Wire.write(registerLSB);
-  Wire.endTransmission();
-
-  if(Wire.available() <=1) {
-    _lsb = Wire.read();
-  }
-
-  return (_lsb) + (_msb & _msbMask) * 256;
+  _hi = _getRegister(registerMSB);
+  _lo = _getRegister(registerLSB);
+  return (_hi<<8) | (_lo);
 }

--- a/AS5600.h
+++ b/AS5600.h
@@ -14,17 +14,25 @@ class AS5600
 {
   public:
     AS5600();
-    long getPosition();
-    int getAngle();
-    int getStatus();
-    int getGain();
-    int getMagnitude();
+    uint16_t getPosition();
+
+    uint16_t getAngle();
+    uint16_t getRawAngle();
+    float getScaledAngle();
+
+    uint8_t getStatus();
+    uint8_t getGain();
+    uint8_t getMagnet();
+    uint16_t getMagnitude();
     void setZero();
-    
-    
-    private: 
+
+    bool isMagnetTooStrong();
+    bool isMagnetTooWeak();
+    bool isMagnetDetected();
+
+    private:
       int _AS5600Address = 0x36;
-      
+
       byte _ZMCOAddress = 0x00;
       byte _ZPOSAddressMSB = 0x01;
       byte _ZPOSAddressLSB = 0x02;
@@ -44,12 +52,8 @@ class AS5600
       byte _MAGNITUDEAddressLSB = 0x1C;
       byte _BURNAddress = 0xFF;
 
-      long _msb;
-      long _lsb;
-      long _msbMask = 0b00001111;
-
-      long _getRegisters2(byte registerMSB, byte registerLSB);
-      int _getRegister(byte register1);
+      uint16_t _getRegisters2(byte registerMSB, byte registerLSB);
+      uint8_t _getRegister(byte register1);
 };
 
 #endif

--- a/examples/readAngle/readAngle.ino
+++ b/examples/readAngle/readAngle.ino
@@ -1,13 +1,14 @@
 #include <AS5600.h>
 
 AS5600 encoder;
-double output;
+float output;
 
 void setup() {
   Serial.begin(9600);
 }
 
 void loop() {
-  output = encoder.getPosition(); // get the absolute position of the encoder
+  // get the angle in degrees of the encoder
+  output = encoder.getAngle();
   Serial.println(output);
 }


### PR DESCRIPTION
* _getRegister2 broken, fixed with call to _getRegister twice
* _getRegister broken, fixed with adding extra parameter to `requestFrom`
* changed types to explicit bit lenght (e.g. `uint16_t`)
* added `isMagnet...` functions for convenience
* added `getScaledAngle` for easy conversion to degrees (0 to 360)
* took out buggy mamber variables `_msb` and `_lsb` variables
* added example for angle
* formatted code
* tested on mocoder (AS5600 breakout)


NOTE: the main fix was to _getRegister2 which was outright broken and _getRegister which needed `requestFrom` with the added parameter to work with my AS5600 and Arduino Uno and to take out the class `_msb` and `_lsb` which were not properly isolated and giving bad results. The rest is mostly just cosmetic.